### PR TITLE
Portability fixes (for NetBSD, Mac OS X, probably others)

### DIFF
--- a/crypto/sha2.c
+++ b/crypto/sha2.c
@@ -1,8 +1,16 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <byteswap.h>
 #include <assert.h>
+
+#if __has_include("byteswap.h")
+#include <byteswap.h>
+#elif __has_include("machine/bswap.h")
+#include <machine/bswap.h>
+#define __bswap_32 __byte_swap_u32_variable
+#else
+#error No byteswap implementation on this platform!
+#endif
 
 #include "sha2.h"
 #include "sha256_sse4.h"


### PR DESCRIPTION
prctl functions are generally only available on linux and irix (and you probably aren't going to run this on irix...) so this removes those and uses sigaction for signal handling instead

it also removes a few unused headers and adds detection for the correct byteswap header on bsd platforms, and a define so the name used works on netbsd

these changes, plus minor alterations to the makefile for my environment, were sufficient to build both benchmark and gen for netbsd/x86_64